### PR TITLE
wip: setup dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+/_build/
+/cover/
+/deps/
+/doc/
+/assets/node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node as ASSET_BUILD
+COPY assets assets
+WORKDIR assets
+RUN npm install
+
+FROM elixir
+COPY --from=ASSET_BUILD assets assets
+RUN mix local.hex --force
+RUN mix local.rebar --force
+COPY mix.exs .
+COPY mix.lock .
+RUN mix deps.get
+COPY . .
+
+ENV MIX_ENV prod
+CMD ["elixir", "-S", "mix", "phx.server"]


### PR DESCRIPTION
Would love some help understanding some errors I'm running into here. This is my first elixir experience so I'm a little out of my depth. 😛 

This builds ok but when I run the docker image I get the following error:

```
** (KeyError) key "SECRET_KEY_BASE" not found in: %{"BINDIR" => "/usr/local/lib/erlang/erts-10.2.3/bin", "ELIXIR_VERSION" => "v1.8.1", "EMU" => "beam", "HOME" => "/root", "HOSTNAME" => "1e004bfefaf2", "LANG" => "C.UTF-8", "MIX_ENV" => "prod", "OTP_VERSION" => "21.2.5", "PATH" => "/usr/local/lib/erlang/erts-10.2.3/bin:/usr/local/lib/erlang/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "PROGNAME" => "erl", "PWD" => "/", "REBAR3_VERSION" => "3.8.0", "REBAR_VERSION" => "2.6.4", "ROOTDIR" => "/usr/local/lib/erlang"}
    (stdlib) :maps.get("SECRET_KEY_BASE", %{"BINDIR" => "/usr/local/lib/erlang/erts-10.2.3/bin", "ELIXIR_VERSION" => "v1.8.1", "EMU" => "beam", "HOME" => "/root", "HOSTNAME" => "1e004bfefaf2", "LANG" => "C.UTF-8", "MIX_ENV" => "prod", "OTP_VERSION" => "21.2.5", "PATH" => "/usr/local/lib/erlang/erts-10.2.3/bin:/usr/local/lib/erlang/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "PROGNAME" => "erl", "PWD" => "/", "REBAR3_VERSION" => "3.8.0", "REBAR_VERSION" => "2.6.4", "ROOTDIR" => "/usr/local/lib/erlang"})
    (stdlib) erl_eval.erl:680: :erl_eval.do_apply/6
    (stdlib) erl_eval.erl:888: :erl_eval.expr_list/6
    (stdlib) erl_eval.erl:240: :erl_eval.expr/5
    (stdlib) erl_eval.erl:232: :erl_eval.expr/5
    (stdlib) erl_eval.erl:233: :erl_eval.expr/5
    (stdlib) erl_eval.erl:888: :erl_eval.expr_list/6
    (stdlib) erl_eval.erl:411: :erl_eval.expr/5
```