### PR TITLE
Always rebuild on Heroku

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,2 +1,3 @@
 erlang_version=21.2
 elixir_version=1.7.4
+always_rebuild=true


### PR DESCRIPTION
Closes #3.

Twitter and Mastodon credentials are optional, and Dolphin will only
post to configured services. When Dolphin is compiled without one of
these, the `(Twitter|Mastodon)configured?/0` function will return false,
preventing the update to be posted to that service.

Currently, both modules use module attributes for quick access to the
credentials. In the case of Mastodon, the module holds a module named
`@base_url`, which is used by the `Hunter` library to know where to post
to.

Since module attributes are set at compile time, compiling Dolphin
without Mastodon credentials and adding them later will result in the
`configured?/0` function to return `true` (as it checks the
configuration set when the app started), but posting to Mastodon will
produce a failure as the module attribute isn't available.

The Heroku buildpack won't recompile the app for each deploy by default,
causing this to happen on Heroku too.

This patch forces a rebuild for every deploy on Heroku. To revert this
later, the `Twitter` and `Mastodon` modules should move off using module
attributes to store credentials.